### PR TITLE
Simplify start script for Render

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -7,76 +7,10 @@ check_docker() {
   return $?
 }
 
-# Start Docker daemon if not running
+# If Docker isn't available, fall back to running the gateway directly
 if ! check_docker; then
-  echo "Starting Docker daemon..."
-  
-  # Create a custom Docker daemon config to work around read-only file system issues
-  mkdir -p /etc/docker
-  cat > /etc/docker/daemon.json << EOL
-{
-  "userns-remap": "default",
-  "storage-driver": "overlay2",
-  "log-driver": "json-file",
-  "log-opts": {
-    "max-size": "10m",
-    "max-file": "3"
-  }
-}
-EOL
-
-  # Try starting Docker with various methods
-  echo "Attempting to start Docker daemon..."
-  
-  # Method 1: Using service command
-  if command -v service > /dev/null 2>&1; then
-    echo "Trying to start Docker using service command..."
-    service docker start > /dev/null 2>&1 || echo "Service start failed, trying next method"
-  fi
-  
-  # Method 2: Using systemctl
-  if ! check_docker && command -v systemctl > /dev/null 2>&1; then
-    echo "Trying to start Docker using systemctl..."
-    systemctl start docker > /dev/null 2>&1 || echo "Systemctl start failed, trying next method"
-  fi
-  
-  # Method 3: Direct dockerd with minimal options
-  if ! check_docker; then
-    echo "Trying to start Docker daemon directly..."
-    mkdir -p /var/run/docker
-    dockerd --host=unix:///var/run/docker.sock --data-root=/var/lib/docker --exec-root=/var/run/docker > /var/log/dockerd.log 2>&1 &
-    
-    # Wait for Docker to be available
-    echo "Waiting for Docker daemon to start..."
-    timeout=60
-    until check_docker || [ $timeout -eq 0 ]; do
-      sleep 2
-      ((timeout-=2))
-      echo "Waiting for Docker to start... ($timeout seconds left)"
-    done
-    
-    if [ $timeout -eq 0 ]; then
-      echo "Docker failed to start. Checking logs:"
-      tail -n 50 /var/log/dockerd.log
-      echo "Trying to run without Docker..."
-      
-      # Print environment for debugging
-      echo "Environment:"
-      env | grep -i docker
-      
-      # List processes
-      echo "Running processes:"
-      ps aux | grep docker
-      
-      # Run the fallback script
-      echo "Attempting to run in fallback mode..."
-      chmod +x /app/fallback.sh
-      exec /app/fallback.sh
-      exit 1
-    fi
-  fi
-  
-  echo "Docker daemon started successfully!"
+  echo "Docker not detected. Running in fallback mode."
+  exec /app/fallback.sh
 fi
 
 # Create a simple docker-compose.override.yml for Render


### PR DESCRIPTION
## Summary
- skip Docker setup in start.sh and run fallback mode when Docker is missing

## Testing
- `bash -n start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a6b2280d888333a4cd0f8ae3f3eb49