### PR TITLE
Add proxy routers for gateway service

### DIFF
--- a/services/gateway-service/app/routers/__init__.py
+++ b/services/gateway-service/app/routers/__init__.py
@@ -1,0 +1,1 @@
+# Routers package for the gateway service

--- a/services/gateway-service/app/routers/ai.py
+++ b/services/gateway-service/app/routers/ai.py
@@ -1,0 +1,4 @@
+from app.core.config import settings
+from .proxy import create_proxy_router
+
+router = create_proxy_router("/ai", settings.AI_SERVICE_URL, tags=["ai"])

--- a/services/gateway-service/app/routers/auth.py
+++ b/services/gateway-service/app/routers/auth.py
@@ -1,0 +1,4 @@
+from app.core.config import settings
+from .proxy import create_proxy_router
+
+router = create_proxy_router("/auth", settings.AUTH_SERVICE_URL, tags=["auth"])

--- a/services/gateway-service/app/routers/blood.py
+++ b/services/gateway-service/app/routers/blood.py
@@ -1,0 +1,4 @@
+from app.core.config import settings
+from .proxy import create_proxy_router
+
+router = create_proxy_router("/blood", settings.BLOOD_SERVICE_URL, tags=["blood"])

--- a/services/gateway-service/app/routers/hospital.py
+++ b/services/gateway-service/app/routers/hospital.py
@@ -1,0 +1,4 @@
+from app.core.config import settings
+from .proxy import create_proxy_router
+
+router = create_proxy_router("/hospital", settings.HOSPITAL_SERVICE_URL, tags=["hospital"])

--- a/services/gateway-service/app/routers/ngo.py
+++ b/services/gateway-service/app/routers/ngo.py
@@ -1,0 +1,4 @@
+from app.core.config import settings
+from .proxy import create_proxy_router
+
+router = create_proxy_router("/ngo", settings.NGO_SERVICE_URL, tags=["ngo"])

--- a/services/gateway-service/app/routers/notification.py
+++ b/services/gateway-service/app/routers/notification.py
@@ -1,0 +1,4 @@
+from app.core.config import settings
+from .proxy import create_proxy_router
+
+router = create_proxy_router("/notification", settings.NOTIFICATION_SERVICE_URL, tags=["notification"])

--- a/services/gateway-service/app/routers/proxy.py
+++ b/services/gateway-service/app/routers/proxy.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Request, Response
+import httpx
+
+
+def create_proxy_router(prefix: str, target_url: str, tags: list[str] | None = None) -> APIRouter:
+    """Create a proxy router forwarding requests to the target service."""
+    router = APIRouter(prefix=prefix, tags=tags or [])
+
+    async def proxy(request: Request, path: str = ""):
+        url = target_url.rstrip("/")
+        if path:
+            url = f"{url}/{path}"
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.request(
+                request.method,
+                url,
+                params=request.query_params,
+                content=await request.body(),
+                headers={k: v for k, v in request.headers.items() if k.lower() != "host"},
+            )
+
+        headers = dict(resp.headers)
+        return Response(content=resp.content, status_code=resp.status_code, headers=headers)
+
+    router.add_api_route("/{path:path}", proxy, methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+    router.add_api_route("", proxy, methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+    return router

--- a/services/gateway-service/app/routers/resource.py
+++ b/services/gateway-service/app/routers/resource.py
@@ -1,0 +1,4 @@
+from app.core.config import settings
+from .proxy import create_proxy_router
+
+router = create_proxy_router("/resource", settings.RESOURCE_SERVICE_URL, tags=["resource"])


### PR DESCRIPTION
## Summary
- add proxy utility and individual routers so gateway can import and forward requests

## Testing
- `python -m py_compile sehat-backend/services/gateway-service/app/main.py`
- `python -m py_compile sehat-backend/services/gateway-service/app/routers/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a73b71917883339a1bd9db62e9fd2f