### PR TITLE
fix: replace union type syntax for proxy router

### DIFF
--- a/services/gateway-service/app/routers/__init__.py
+++ b/services/gateway-service/app/routers/__init__.py
@@ -1,0 +1,1 @@
+# Package for gateway service routers.

--- a/services/gateway-service/app/routers/ai.py
+++ b/services/gateway-service/app/routers/ai.py
@@ -1,0 +1,6 @@
+"""AI service proxy router."""
+
+from app.core.config import settings
+from .proxy import create_proxy_router
+
+router = create_proxy_router("/ai", settings.AI_SERVICE_URL, tags=["ai"])

--- a/services/gateway-service/app/routers/auth.py
+++ b/services/gateway-service/app/routers/auth.py
@@ -1,0 +1,6 @@
+"""Authentication service proxy router."""
+
+from app.core.config import settings
+from .proxy import create_proxy_router
+
+router = create_proxy_router("/auth", settings.AUTH_SERVICE_URL, tags=["auth"])

--- a/services/gateway-service/app/routers/blood.py
+++ b/services/gateway-service/app/routers/blood.py
@@ -1,0 +1,6 @@
+"""Blood service proxy router."""
+
+from app.core.config import settings
+from .proxy import create_proxy_router
+
+router = create_proxy_router("/blood", settings.BLOOD_SERVICE_URL, tags=["blood"])

--- a/services/gateway-service/app/routers/hospital.py
+++ b/services/gateway-service/app/routers/hospital.py
@@ -1,0 +1,6 @@
+"""Hospital service proxy router."""
+
+from app.core.config import settings
+from .proxy import create_proxy_router
+
+router = create_proxy_router("/hospitals", settings.HOSPITAL_SERVICE_URL, tags=["hospitals"])

--- a/services/gateway-service/app/routers/ngo.py
+++ b/services/gateway-service/app/routers/ngo.py
@@ -1,0 +1,6 @@
+"""NGO service proxy router."""
+
+from app.core.config import settings
+from .proxy import create_proxy_router
+
+router = create_proxy_router("/ngos", settings.NGO_SERVICE_URL, tags=["ngos"])

--- a/services/gateway-service/app/routers/notification.py
+++ b/services/gateway-service/app/routers/notification.py
@@ -1,0 +1,6 @@
+"""Notification service proxy router."""
+
+from app.core.config import settings
+from .proxy import create_proxy_router
+
+router = create_proxy_router("/notifications", settings.NOTIFICATION_SERVICE_URL, tags=["notifications"])

--- a/services/gateway-service/app/routers/proxy.py
+++ b/services/gateway-service/app/routers/proxy.py
@@ -1,0 +1,23 @@
+from typing import List, Optional
+
+from fastapi import APIRouter, Request, Response
+import httpx
+
+
+def create_proxy_router(prefix: str, target_url: str, tags: Optional[List[str]] = None) -> APIRouter:
+    """Create a router that proxies all requests to another service."""
+    router = APIRouter(prefix=prefix, tags=tags)
+
+    @router.api_route("/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
+    async def proxy(request: Request, path: str) -> Response:
+        async with httpx.AsyncClient(base_url=target_url) as client:
+            resp = await client.request(
+                request.method,
+                path,
+                headers={k: v for k, v in request.headers.items() if k.lower() != "host"},
+                params=request.query_params,
+                content=await request.body(),
+            )
+        return Response(content=resp.content, status_code=resp.status_code, headers=dict(resp.headers))
+
+    return router

--- a/services/gateway-service/app/routers/resource.py
+++ b/services/gateway-service/app/routers/resource.py
@@ -1,0 +1,6 @@
+"""Resource service proxy router."""
+
+from app.core.config import settings
+from .proxy import create_proxy_router
+
+router = create_proxy_router("/resources", settings.RESOURCE_SERVICE_URL, tags=["resources"])


### PR DESCRIPTION
## Summary
- use `typing.Optional` for proxy router tags to avoid Python 3.10 union operator
- add gateway proxy routers for microservices

## Testing
- `pytest`
- `python -m py_compile $(git ls-files 'services/gateway-service/app/**/*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a9249c4b1c83338313f280ad5f268c